### PR TITLE
Improve error handling when using options from disabled plugins. Closes #289

### DIFF
--- a/m365-developer-proxy/Program.cs
+++ b/m365-developer-proxy/Program.cs
@@ -17,14 +17,20 @@ pluginEvents.RaiseInit(new InitArgs(rootCommand));
 
 rootCommand.Handler = proxyHost.GetCommandHandler(pluginEvents, loaderResults.UrlsToWatch, logger);
 
+// store the global options that are created automatically for us
+string[] globalOptions = { "--version", "-?", "-h", "--help" };
+
 // filter args to retrieve short (-n) and long (--name) option aliases
 var incomingOptions = args.Where(arg => arg.StartsWith("-") || arg.StartsWith("--")).ToArray();
+
+// remove the global options from the incoming options
+incomingOptions = incomingOptions.Except(globalOptions).ToArray();
 
 // compare the incoming options against the root command options
 foreach (var option in rootCommand.Options)
 {
     // get the option aliases
-    string[] aliases = option.Aliases.ToArray();
+    var aliases = option.Aliases.ToArray();
 
     // iterate over aliases
     foreach (string alias in aliases)
@@ -42,6 +48,7 @@ foreach (var option in rootCommand.Options)
 if (incomingOptions.Length > 0)
 {
     logger.LogInfo($"Unknown option(s): {string.Join(" ", incomingOptions)}");
+    logger.LogInfo($"TIP: Use -?, -h or --help to view available options");
     logger.LogInfo($"TIP: Are you missing a plugin? See: https://aka.ms/m365/proxy/plugins");
 }
 else

--- a/m365-developer-proxy/Program.cs
+++ b/m365-developer-proxy/Program.cs
@@ -18,10 +18,10 @@ pluginEvents.RaiseInit(new InitArgs(rootCommand));
 rootCommand.Handler = proxyHost.GetCommandHandler(pluginEvents, loaderResults.UrlsToWatch, logger);
 
 // filter args to retrieve short (-n) and long (--name) option aliases
-string[] incomingOptions = args.Where(arg => arg.StartsWith("-") || arg.StartsWith("--")).ToArray();
+var incomingOptions = args.Where(arg => arg.StartsWith("-") || arg.StartsWith("--")).ToArray();
 
 // compare the incoming options against the root command options
-foreach (Option option in rootCommand.Options)
+foreach (var option in rootCommand.Options)
 {
     // get the option aliases
     string[] aliases = option.Aliases.ToArray();
@@ -44,5 +44,7 @@ if (incomingOptions.Length > 0)
     logger.LogInfo($"Unknown option(s): {string.Join(" ", incomingOptions)}");
     logger.LogInfo($"TIP: Are you missing a plugin? See: https://aka.ms/m365/proxy/plugins");
 }
-
-await rootCommand.InvokeAsync(args);
+else
+{
+    await rootCommand.InvokeAsync(args);
+}

--- a/m365-developer-proxy/Properties/launchSettings.json
+++ b/m365-developer-proxy/Properties/launchSettings.json
@@ -33,6 +33,10 @@
     "Default": {
       "commandName": "Project",
       "hotReloadEnabled": true
+    },
+    "Missing arg": {
+      "commandName": "Project",
+      "commandLineArgs": "--port 8080 --summary-file-path report.md"
     }
   }
 }


### PR DESCRIPTION
Closes #289 

Merging this PR will

- Add error handling to compare the incoming short (-n) and long (--name) option aliases against the option aliases loaded from the proxy and plugins.
- No longer invoke `--help` output when an error is thrown.
- Add a TIP message to use `--help` to view available options.
- Add a TIP message with link to guidance for enabling plugins when a unknown option is used.

![image](https://github.com/microsoft/m365-developer-proxy/assets/11563347/4d15545d-bd8b-495f-a062-a8cd8f670fee)

EDIT: 2023-08-10 15:47 - Addressed PR review comments
EDIT: 2023-08-11 09:08 - Addressed PR review comments
